### PR TITLE
Add hook for changing multiplicative suffix to dd operations to automati...

### DIFF
--- a/zxfer
+++ b/zxfer
@@ -184,6 +184,9 @@ fbsd_readonly_properties="aclmode,aclinherit,devices,nbmand,shareiscsi,vscan,xat
 # Properties not supported on Solaris Express 11
 solexp_readonly_properties="jailed,aclmode,shareiscsi"
 
+# Multiplicative Suffix for dd operations: defaults to 'm' as in 'dd bs=1m' for freebsd
+dd_mult_suffix="m"
+
 #
 # Beeps a success sound if -B enabled, and a failure sound if -b or -B enabled.
 # Takes: $exit_status (0 if success, 1 if failure)
@@ -245,6 +248,7 @@ init_variables() {
 
   if [ "$home_os" = "SunOS" ]; then
     AWK=$( which gawk )
+    dd_mult_suffix="M"
   fi
  }
 
@@ -408,7 +412,7 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo "$option_D" | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send "$copysrc" | dd obs=1m | dd bs=1m | $PROGRESS_DIALOG | \
+          $LZFS send "$copysrc" | dd obs=1"$dd_mult_suffix" | dd bs=1"$dd_mult_suffix" | $PROGRESS_DIALOG | \
             $RZFS receive $option_F "$copydest" || \
             { echo "Error when zfs send/receiving."; beep; exit 1; }
         else
@@ -419,7 +423,7 @@ copy_snap() {
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
           $LZFS send -nv "$copysrc"
-          echo "$LZFS send $copysrc | dd obs=1m | dd bs=1m | $PROGRESS_DIALOG |
+          echo "$LZFS send $copysrc | dd obs=1"$dd_mult_suffix" | dd bs=1"$dd_mult_suffix" | $PROGRESS_DIALOG |
             $RZFS receive $option_F $copydest"
         fi
       else
@@ -440,7 +444,7 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send -i "$copyprev" "$copysrc" | dd obs=1m | dd bs=1m | \
+          $LZFS send -i "$copyprev" "$copysrc" | dd obs=1"$dd_mult_suffix" | dd bs=1"$dd_mult_suffix" | \
             $PROGRESS_DIALOG | $RZFS receive $option_F "$copydest" || \
             { echo "Error when zfs send/receiving."; beep; exit 1; }        
         else
@@ -451,7 +455,7 @@ copy_snap() {
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
           $LZFS send -nv -i "$copyprev" "$copysrc"
-          echo "$LZFS send -i $copyprev $copysrc | dd obs=1m | dd bs=1m | \
+          echo "$LZFS send -i $copyprev $copysrc | dd obs=1"$dd_mult_suffix" | dd bs=1"$dd_mult_suffix" | \
             $PROGRESS_DIALOG | $RZFS receive $option_F $copydest"      
         fi
       else


### PR DESCRIPTION
...cally change based upon OS and make the change for Solaris

When zxfer is called with the -D option on Solaris (I'm using OmniOS a derivative of the OpenIndiana project), the zfs send/recv fail due to dd being called with errors like:

``` sh
...
Estimated size is: 563945097936
dd: invalid number ‘1m’
dd: invalid number ‘1m’
   0.0B  at    0.0B/s   eta:   0:00:00    0% [=                                                                                              ]
Copied: 0B (0.0B ) (0% of expected input)
Time:  0 seconds
Throughput: (infinite)

cannot receive: failed to read from stream
Error when zfs send/receiving.
```

The suffix for the dd commands was hardcoded to '1m' when the -D option was added.  This pull request adds the ability to automagically change this for Solaris to a '1M' but default to '1m' for other OSes.
