### PR TITLE
Added Linux ZFS support....

### DIFF
--- a/zxfer
+++ b/zxfer
@@ -189,7 +189,7 @@ fbsd11_readonly_properties="devices,nbmand,shareiscsi,snapdev,vscan,xattr,zoned"
 solexp_readonly_properties="jailed,aclmode,shareiscsi"
 
 # Properties not support on Linux
-linux_readonly_properties="jailed,aclmode,shareiscsi"
+linux_readonly_properties="jailed,aclmode,shareiscsi,volmode"
 
 #
 # Beeps a success sound if -B enabled, and a failure sound if -b or -B enabled.

--- a/zxfer
+++ b/zxfer
@@ -94,7 +94,7 @@
 #           Where destination is a ZFS filesystem e.g.  poolname/fsname
 
 # zxfer version
-zxfer_version="1.1.6-20160214"
+zxfer_version="1.1.7-20171107"
 
 # Default values
 option_b=0
@@ -180,10 +180,16 @@ refcompressratio,written,logicalused,logicalreferenced"
 
 
 # Properties not supported on FreeBSD 9.3
-fbsd_readonly_properties="aclmode,aclinherit,devices,nbmand,shareiscsi,vscan,xattr"
+fbsd_readonly_properties="aclmode,aclinherit,devices,nbmand,shareiscsi,snapdev,vscan,xattr,zoned"
+
+# Properties not supported on FreeBSD 10+
+fbsd11_readonly_properties="devices,nbmand,shareiscsi,snapdev,vscan,xattr,zoned"
 
 # Properties not supported on Solaris Express 11
 solexp_readonly_properties="jailed,aclmode,shareiscsi"
+
+# Properties not support on Linux
+linux_readonly_properties="jailed,aclmode,shareiscsi"
 
 #
 # Beeps a success sound if -B enabled, and a failure sound if -b or -B enabled.
@@ -216,10 +222,12 @@ fi
 get_os() {
   input_optionts=$1
   output_os=""
+  output_osver=""
 
   # Get uname of the destination (target) machine, local or remote 
   if [ "$input_optionts" = "" ]; then
     output_os=$(uname)
+    output_osver=$(uname -r)
   else 
     output_os=$($input_optionts uname)
   fi
@@ -232,9 +240,13 @@ get_os() {
 init_variables() {
   get_os "$option_T"
   dest_os="$output_os"
+  # Stupid way to detect if FreeBSD 10 through 19
+  dest_osver=(printf %.1s "$output_osver")
   
   get_os "$option_O"
   source_os="$output_os"
+  # Stupid way to detect if FreeBSD 10 through 19
+  source_osver=(printf %.1s "$output_osver")
   
   if [ $option_e -eq 1 ]; then
     LCAT=$( ${option_O} which cat )
@@ -1432,8 +1444,14 @@ $override_value=$override_source,"
     done
   fi
 
+  =$(printf %.1s "$1")
+
   # Remove several properties not supported on FreeBSD.
-  if [ "$dest_os" = "FreeBSD" ]; then
+  # Basic check for FreeBSD 10 through 19... :P
+  if [ "$dest_os" = "FreeBSD" -a "$dest_osver" = "1"]; then
+    readonly_properties="$readonly_properties,$fbsd11_readonly_properties"
+  # Assume is FreeBSD 9 or earlier
+  else if [ "$dest_os" = "FreeBSD" ]; then
     readonly_properties="$readonly_properties,$fbsd_readonly_properties"
   fi
 
@@ -1441,6 +1459,10 @@ $override_value=$override_source,"
   if [ "$dest_os" = "SunOS" -a "$source_os" = "FreeBSD" ]; then
     readonly_properties="$readonly_properties,$solexp_readonly_properties"
   fi
+
+  # Remove several properties not supported on Linux.
+  if [ "$dest_os" = "Linux" ]; then
+    readonly_properties="$readonly_properties,$linux_readonly_properties"
 
   # Remove the readonly properties and values.
   remove_properties "$override_pvs" "$readonly_properties"

--- a/zxfer
+++ b/zxfer
@@ -241,12 +241,12 @@ init_variables() {
   get_os "$option_T"
   dest_os="$output_os"
   # Stupid way to detect if FreeBSD 10 through 19
-  dest_osver=(printf %.1s "$output_osver")
+  dest_osver=$(printf %.1s "$output_osver")
   
   get_os "$option_O"
   source_os="$output_os"
   # Stupid way to detect if FreeBSD 10 through 19
-  source_osver=(printf %.1s "$output_osver")
+  source_osver=$(printf %.1s "$output_osver")
   
   if [ $option_e -eq 1 ]; then
     LCAT=$( ${option_O} which cat )
@@ -1444,15 +1444,14 @@ $override_value=$override_source,"
     done
   fi
 
-  =$(printf %.1s "$1")
-
-  # Remove several properties not supported on FreeBSD.
+    # Remove several properties not supported on FreeBSD.
   # Basic check for FreeBSD 10 through 19... :P
-  if [ "$dest_os" = "FreeBSD" -a "$dest_osver" = "1"]; then
+  if [ "$dest_os" = "FreeBSD" -a "$dest_osver" = "1" ]; then
     readonly_properties="$readonly_properties,$fbsd11_readonly_properties"
   # Assume is FreeBSD 9 or earlier
-  else if [ "$dest_os" = "FreeBSD" ]; then
-    readonly_properties="$readonly_properties,$fbsd_readonly_properties"
+    else if [ "$dest_os" = "FreeBSD" ]; then
+      readonly_properties="$readonly_properties,$fbsd_readonly_properties"
+    fi
   fi
 
   # Remove several properties not supported on Solaris Express.
@@ -1463,6 +1462,7 @@ $override_value=$override_source,"
   # Remove several properties not supported on Linux.
   if [ "$dest_os" = "Linux" ]; then
     readonly_properties="$readonly_properties,$linux_readonly_properties"
+  fi
 
   # Remove the readonly properties and values.
   remove_properties "$override_pvs" "$readonly_properties"


### PR DESCRIPTION
Okay, so I primarily use FreeBSD, but I do have a Linux box and a couple VM's that use ZFS.  So I added an OS check condition for Linux so that unsupported properties are dealt with.  At least I was only able to determine that jailed,aclmode,shareiscsi,and volmode don't work when receiving from FreeBSD.

As well, I noticed that the latest version was restricting current versions of FreeBSD even though aclmode and aclinherit are now supported.  So to ensure this was not just a Linux adaptation of an amazing tool, I added a really dumb check to differentiate between FreeBSD >= 10 and <10 (using the first number of the release version, so it isn't future-proofed after FreeBSD 19...)