### PR TITLE
Remove optimization which breaks local replication

### DIFF
--- a/zxfer
+++ b/zxfer
@@ -685,12 +685,8 @@ get_zfs_list() {
   # gtac line
   lzfs_list_hr_S_snap=$(echo "$lzfs_list_hr_s_snap" | cat -n)
   lzfs_list_hr_S_snap=$(echo "$lzfs_list_hr_S_snap" | sort -nr | cut -c 8- )
-  if [ "$RZFS" = "$LZFS" ]; then
-    rzfs_list_hr_S_snap=$lzfs_list_hr_S_snap
-  else
-    rzfs_list_hr_S_snap=$($RZFS list -Hr -o name -S creation -t snapshot $destination) ||
-      { echo "Failed to retrieve snapshots from the destination"; exit 3; }
-  fi
+  rzfs_list_hr_S_snap=$($RZFS list -Hr -o name -S creation -t snapshot $destination) ||
+    { echo "Failed to retrieve snapshots from the destination"; exit 3; }
 
   recursive_source_list=$($LZFS list -t filesystem,volume -Hr -o name "$initial_source") ||
     { echo "Failed to retrieve list of datasets from the source"; exit 3; }


### PR DESCRIPTION
The optimization in get_zfs_list() which saved time when LZFS and RZFS
are identical (meaning the source and target machines are local, or
identical remotes) did not actually work. The snapshot list from the
target machine was incorrect, resulting in zxfer believing it had
to send the entire filesystem and all snapshots, even if a previous
replication had sent them.

Removing the optimization resolves the issue; local-to-local replication
now works as expected, incrementally sending new snapshots on each
run. Remote replication should be unaffected except for the unusual
case where the source and target remotes are the same system; in that case,
the snapshot information gathering process will take slightly more time.

Resolves issue #42.