### PR TITLE
Declare new readonly properties: createtxg and guid

### DIFF
--- a/zxfer
+++ b/zxfer
@@ -176,7 +176,7 @@ readonly_properties="type,creation,used,available,referenced,\
 compressratio,mounted,version,primarycache,secondarycache,\
 usedbysnapshots,usedbydataset,usedbychildren,usedbyrefreservation,\
 version,volsize,mountpoint,mlslabel,keysource,keystatus,rekeydate,encryption,\
-refcompressratio,written,logicalused,logicalreferenced"
+refcompressratio,written,logicalused,logicalreferenced,createtxg,guid"
 
 
 # Properties not supported on FreeBSD 9.3


### PR DESCRIPTION
Confirmed with:
* FreeBSD 12.0-RELEASE
* CentOS 7.6 with ZFS on Linux (ZoL) 0.7.12

For originating issue, see #46 