### PR TITLE
-D flag fails with error when run on Linux.

### DIFF
--- a/zxfer
+++ b/zxfer
@@ -409,7 +409,7 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo "$option_D" | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send "$copysrc" | dd obs=1m | dd bs=1m | $PROGRESS_DIALOG | \
+          $LZFS send "$copysrc" | dd obs=1048576 | dd bs=1048576 | $PROGRESS_DIALOG | \
             $RZFS receive $option_F "$copydest" || \
             { echo "Error when zfs send/receiving."; beep; exit 1; }
         else
@@ -420,7 +420,7 @@ copy_snap() {
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
           $LZFS send -nv "$copysrc"
-          echo "$LZFS send $copysrc | dd obs=1m | dd bs=1m | $PROGRESS_DIALOG |
+          echo "$LZFS send $copysrc | dd obs=1048576 | dd bs=1048576 | $PROGRESS_DIALOG |
             $RZFS receive $option_F $copydest"
         fi
       else
@@ -441,7 +441,7 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send -i "$copyprev" "$copysrc" | dd obs=1m | dd bs=1m | \
+          $LZFS send -i "$copyprev" "$copysrc" | dd obs=1048576 | dd bs=1048576 | \
             $PROGRESS_DIALOG | $RZFS receive $option_F "$copydest" || \
             { echo "Error when zfs send/receiving."; beep; exit 1; }
         else
@@ -452,7 +452,7 @@ copy_snap() {
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
           $LZFS send -nv -i "$copyprev" "$copysrc"
-          echo "$LZFS send -i $copyprev $copysrc | dd obs=1m | dd bs=1m | \
+          echo "$LZFS send -i $copyprev $copysrc | dd obs=1048576 | dd bs=1048576 | \
             $PROGRESS_DIALOG | $RZFS receive $option_F $copydest"      
         fi
       else


### PR DESCRIPTION
Using the "1m" abbreviation for block size on dd is not a good idea, as various implementations of dd make use of different abbreviations. Instaed, it seems like both dd implementations take bytes as arguments. So translating 1m to bytes seem to be an easy solution.

replaced obs=1m with obs=1048576 (same for bs=) to be compatible with both BSD and Linux versions of dd.