### PR TITLE
Ensure quotes around ZFS option argument values survive eval

### DIFF
--- a/zxfer
+++ b/zxfer
@@ -1463,7 +1463,7 @@ $override_value=$override_source,"
       # as this is the initial source, we want to transfer all properties from
       # the source, overridden with option_o values as necessary 
       remove_sources "$override_pvs"
-      override_option_list=$(echo "$new_rmvs_pv" | tr "," "\n" | sed "s/\(.*\)=\(.*\)/\1=\'\2\'/g" | tr "\n" "," | sed 's/,$//' | sed -e 's/,/ -o /g')
+      override_option_list=$(echo "$new_rmvs_pv" | tr "," "\n" | sed "s/\(.*\)=\(.*\)/\1=\\\'\2\\\'/g" | tr "\n" "," | sed 's/,$//' | sed -e 's/,/ -o /g')
       if [ "$override_option_list" != "" ]; then
         override_option_list=" -o $override_option_list"
       fi
@@ -1503,7 +1503,7 @@ with specified properties."
       creation_pvs="$new_rmv_pvs"
 
       remove_sources "$creation_pvs"
-      creation_option_list=$(echo "$new_rmvs_pv" | tr "," "\n" | sed "s/\(.*\)=\(.*\)/\1=\'\2\'/" | tr "\n" "," | sed 's/,$//' | sed -e 's/,/ -o /g')
+      creation_option_list=$(echo "$new_rmvs_pv" | tr "," "\n" | sed "s/\(.*\)=\(.*\)/\1=\\\'\2\\\'/" | tr "\n" "," | sed 's/,$//' | sed -e 's/,/ -o /g')
 
       if [ "$creation_option_list" != "" ]; then
         creation_option_list=" -o $creation_option_list"


### PR DESCRIPTION
I found that when using zxfer(8) to transfer iocage(8) datasets I was getting a "too many arguments".
Running with `/bin/sh -x` I was able to see that the values of `zfs create` options were not being quoted, and values with spaces were being interpreted as a value plus additional arguments to zfs(8).

Although I see #25 added the code to include quoting values, it looks like `eval` was removing them.  By adding additional escapes, `eval` does not remove them and so the values are correctly quoted.