### PR TITLE
Added 'objsetid' to readonly_properties

### DIFF
--- a/zxfer
+++ b/zxfer
@@ -178,7 +178,7 @@ usedbysnapshots,usedbydataset,usedbychildren,usedbyrefreservation,\
 version,volsize,mountpoint,mlslabel,keysource,keystatus,rekeydate,encryption,\
 refcompressratio,written,logicalused,logicalreferenced,createtxg,guid,origin,\
 filesystem_count,snapshot_count,clones,defer_destroy,receive_resume_token,\
-userrefs"
+userrefs,objsetid"
 
 # Properties not supported on FreeBSD
 fbsd_readonly_properties="aclmode,aclinherit,devices,nbmand,shareiscsi,vscan,\


### PR DESCRIPTION
I had an issue using zxfer to replicate a pool to a local USB drive with FreeBSD 12.2

```
Creating destination filesystem "backup2/pools/data" with specified properties.
cannot create 'backup2/pools/data': 'objsetid' is readonly
```

After some investigation it seems that 'objsetid' is also a readonly parameter.
I added it to the list of readonly_properties and it worked immediately.
