### PR TITLE
[zfs send -w] Support sending encrypted datasets

### DIFF
--- a/zxfer
+++ b/zxfer
@@ -125,6 +125,7 @@ option_T=""
 option_u=0
 option_U=0
 option_v=0
+option_w=0
 exit_status=1 # defaults to failure
 
 services=""
@@ -258,7 +259,7 @@ init_variables() {
 usage() {
 cat <<EOT
 usage: 
-     zxfer [-dFnPsUv] [-k | -e] [-b | -B] {-N path/to/src | -R path/to/src}
+     zxfer [-dFnPsUvw] [-k | -e] [-b | -B] {-N path/to/src | -R path/to/src}
            [-m [c FMRI|pattern[ FMRI|pattern]...]]] [-O user@host]
            [-D 'progress dialog options'] [-I properties,to,ignore]
            [-T user@host] [-o option1=value1,option2=value2...] [-g days]
@@ -357,6 +358,12 @@ consistency_check() {
       usage
       exit 1
     fi
+
+    if [ $option_w -eq 1 ]; then
+      echo "Error: -w option cannot be used with -S (rsync mode)"
+      usage
+      exit 1
+    fi
   
   else
     #zfs send mode
@@ -373,7 +380,21 @@ consistency_check() {
       usage
       exit 1
     fi
+
+    # disallow -w with -U, else zfs receive won't work
+    if [ $option_w -eq 1 -a $option_U -eq 1 ]; then
+      echo "Error: -w (raw send) option cannot be used with -U"
+      usage
+      exit 1
+    fi
   
+    # disallow -w with -P, else zfs receive won't work
+    if [ $option_w -eq 1 -a $option_U -eq 1 ]; then
+      echo "Error: -w (raw send) option cannot be used with -P"
+      usage
+      exit 1
+    fi
+
     # disallow migration related options and remote transfers at same time
     if [ "$option_T" != "" -o "$option_O" != "" ]; then
       if [ $option_m -eq 1 -o "$services" != "" ]; then
@@ -399,6 +420,11 @@ copy_snap() {
   copydest=$dest
   copyprev=$lastsnap
   copysrctail=$( echo "$copysrc" | cut -d/ -f2- )
+  if [ $option_w -eq 0 ]; then
+    zfssendflags=""
+  else
+    zfssendflags="-w"
+  fi
 
   if [ -z "$( echo "$rzfs_list_ho_s" | grep "^$dest/$copysrctail" )" ]; then
     echov "Sending $copysrc to $copydest."
@@ -411,7 +437,7 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo "$option_D" | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send "$copysrc" | dd obs=1048576 | dd bs=1048576 | $PROGRESS_DIALOG | \
+          $LZFS send $zfssendflags "$copysrc" | dd obs=1048576 | dd bs=1048576 | $PROGRESS_DIALOG | \
             $RZFS receive $option_F "$copydest" || \
             { echo "Error when zfs send/receiving."; beep; exit 1; }
         else
@@ -421,16 +447,16 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send -nv "$copysrc"
-          echo "$LZFS send $copysrc | dd obs=1048576 | dd bs=1048576 | $PROGRESS_DIALOG |
+          $LZFS send $zfssendflags -nv "$copysrc"
+          echo "$LZFS send $zfssendflags $copysrc | dd obs=1048576 | dd bs=1048576 | $PROGRESS_DIALOG |
             $RZFS receive $option_F $copydest"
         fi
       else
         if [ $option_n -eq 0 ]; then
-          $LZFS send "$copysrc" | $RZFS receive $option_F "$copydest" || \
+          $LZFS send $zfssendflags "$copysrc" | $RZFS receive $option_F "$copydest" || \
             { echo "Error when zfs send/receiving."; beep; exit 1; }        
         else
-          echo "$LZFS send $copysrc | $RZFS receive $option_F $copydest"
+          echo "$LZFS send $zfssendflags $copysrc | $RZFS receive $option_F $copydest"
         fi
       fi
     else
@@ -443,7 +469,7 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send -i "$copyprev" "$copysrc" | dd obs=1048576 | dd bs=1048576 | \
+          $LZFS send $zfssendflags -i "$copyprev" "$copysrc" | dd obs=1048576 | dd bs=1048576 | \
             $PROGRESS_DIALOG | $RZFS receive $option_F "$copydest" || \
             { echo "Error when zfs send/receiving."; beep; exit 1; }
         else
@@ -453,16 +479,16 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send -nv -i "$copyprev" "$copysrc"
-          echo "$LZFS send -i $copyprev $copysrc | dd obs=1048576 | dd bs=1048576 | \
+          $LZFS send $zfssendflags -nv -i "$copyprev" "$copysrc"
+          echo "$LZFS send $zfssendflags -i $copyprev $copysrc | dd obs=1048576 | dd bs=1048576 | \
             $PROGRESS_DIALOG | $RZFS receive $option_F $copydest"      
         fi
       else
         if [ $option_n -eq 0 ]; then
-          $LZFS send -i "$copyprev" "$copysrc" | $RZFS receive $option_F "$copydest" \
+          $LZFS send $zfssendflags -i "$copyprev" "$copysrc" | $RZFS receive $option_F "$copydest" \
             || { echo "Error when zfs send/receiving."; beep; exit 1; }
         else
-          echo "$LZFS send -i $copyprev $copysrc | $RZFS receive $option_F
+          echo "$LZFS send $zfssendflags -i $copyprev $copysrc | $RZFS receive $option_F
             $copydest"
         fi
       fi
@@ -1867,7 +1893,7 @@ $backup_file_dir/$backup_file_extension.$is_tail\" | $option_T sh"
 #
 
 # Read command line switches
-while getopts bBc:deE:f:Fg:hiI:klL:lmnN:o:O:pPPR:sST:u:Uv?:D: i
+while getopts bBc:deE:f:Fg:hiI:klL:lmnN:o:O:pPPR:sST:u:Uvw?:D: i
 do
   case $i in
     b)
@@ -1971,6 +1997,9 @@ do
       ;;
     v)
       option_v=1
+      ;;
+    w)
+      option_w=1
       ;;
     \?)
       usage

--- a/zxfer
+++ b/zxfer
@@ -389,7 +389,7 @@ consistency_check() {
     fi
   
     # disallow -w with -P, else zfs receive won't work
-    if [ $option_w -eq 1 -a $option_U -eq 1 ]; then
+    if [ $option_w -eq 1 -a $option_P -eq 1 ]; then
       echo "Error: -w (raw send) option cannot be used with -P"
       usage
       exit 1

--- a/zxfer
+++ b/zxfer
@@ -126,6 +126,8 @@ option_u=0
 option_U=0
 option_v=0
 option_w=0
+option_z=""
+option_Z=""
 exit_status=1 # defaults to failure
 
 services=""
@@ -364,7 +366,19 @@ consistency_check() {
       usage
       exit 1
     fi
-  
+
+    if [ "$option_z" != "" ]; then
+      echo "Error: -z option cannot be used with -S (rsync mode)"
+      usage
+      exit 1
+    fi
+
+    if [ "$option_Z" != "" ]; then
+      echo "Error: -Z option cannot be used with -S (rsync mode)"
+      usage
+      exit 1
+    fi
+
   else
     #zfs send mode
   
@@ -420,11 +434,11 @@ copy_snap() {
   copydest=$dest
   copyprev=$lastsnap
   copysrctail=$( echo "$copysrc" | cut -d/ -f2- )
-  if [ $option_w -eq 0 ]; then
-    zfssendflags=""
-  else
-    zfssendflags="-w"
+  zfssend_flags="$option_z"
+  if [ $option_w -eq 1 ]; then
+    zfssend_flags="${zfssend_flags} -w"
   fi
+  zfsreceive_flags="$option_Z $option_F"
 
   if [ -z "$( echo "$rzfs_list_ho_s" | grep "^$dest/$copysrctail" )" ]; then
     echov "Sending $copysrc to $copydest."
@@ -437,8 +451,8 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo "$option_D" | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send $zfssendflags "$copysrc" | dd obs=1048576 | dd bs=1048576 | $PROGRESS_DIALOG | \
-            $RZFS receive $option_F "$copydest" || \
+          $LZFS send $zfssend_flags "$copysrc" | dd obs=1048576 | dd bs=1048576 | $PROGRESS_DIALOG | \
+            $RZFS receive $zfsreceive_flags "$copydest" || \
             { echo "Error when zfs send/receiving."; beep; exit 1; }
         else
           SIZE_DATASET=$( $LZFS send -nPv "$copysrc" 2>&1 ) ||
@@ -447,16 +461,16 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send $zfssendflags -nv "$copysrc"
-          echo "$LZFS send $zfssendflags $copysrc | dd obs=1048576 | dd bs=1048576 | $PROGRESS_DIALOG |
-            $RZFS receive $option_F $copydest"
+          $LZFS send $zfssend_flags -nv "$copysrc"
+          echo "$LZFS send $zfssend_flags $copysrc | dd obs=1048576 | dd bs=1048576 | $PROGRESS_DIALOG |
+            $RZFS receive $zfsreceive_flags $copydest"
         fi
       else
         if [ $option_n -eq 0 ]; then
-          $LZFS send $zfssendflags "$copysrc" | $RZFS receive $option_F "$copydest" || \
+          $LZFS send $zfssend_flags "$copysrc" | $RZFS receive $zfsreceive_flags "$copydest" || \
             { echo "Error when zfs send/receiving."; beep; exit 1; }        
         else
-          echo "$LZFS send $zfssendflags $copysrc | $RZFS receive $option_F $copydest"
+          echo "$LZFS send $zfssend_flags $copysrc | $RZFS receive $zfsreceive_flags $copydest"
         fi
       fi
     else
@@ -469,8 +483,8 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send $zfssendflags -i "$copyprev" "$copysrc" | dd obs=1048576 | dd bs=1048576 | \
-            $PROGRESS_DIALOG | $RZFS receive $option_F "$copydest" || \
+          $LZFS send $zfssend_flags -i "$copyprev" "$copysrc" | dd obs=1048576 | dd bs=1048576 | \
+            $PROGRESS_DIALOG | $RZFS receive $zfsreceive_flags "$copydest" || \
             { echo "Error when zfs send/receiving."; beep; exit 1; }
         else
           SIZE_DATASET=$( $LZFS send -nPv -i "$copyprev" "$copysrc" 2>&1 ) ||
@@ -479,16 +493,16 @@ copy_snap() {
           echo "Estimated size is: ${SIZE_EST}"
           PROGRESS_DIALOG=$( echo $option_D | sed "s#%%size%%#$SIZE_EST#g" | \
             sed "s#%%title%%#$copysrc#g" )
-          $LZFS send $zfssendflags -nv -i "$copyprev" "$copysrc"
-          echo "$LZFS send $zfssendflags -i $copyprev $copysrc | dd obs=1048576 | dd bs=1048576 | \
-            $PROGRESS_DIALOG | $RZFS receive $option_F $copydest"      
+          $LZFS send $zfssend_flags -nv -i "$copyprev" "$copysrc"
+          echo "$LZFS send $zfssend_flags -i $copyprev $copysrc | dd obs=1048576 | dd bs=1048576 | \
+            $PROGRESS_DIALOG | $RZFS receive $zfsreceive_flags $copydest"
         fi
       else
         if [ $option_n -eq 0 ]; then
-          $LZFS send $zfssendflags -i "$copyprev" "$copysrc" | $RZFS receive $option_F "$copydest" \
+          $LZFS send $zfssend_flags -i "$copyprev" "$copysrc" | $RZFS receive $zfsreceive_flags "$copydest" \
             || { echo "Error when zfs send/receiving."; beep; exit 1; }
         else
-          echo "$LZFS send $zfssendflags -i $copyprev $copysrc | $RZFS receive $option_F
+          echo "$LZFS send $zfssend_flags -i $copyprev $copysrc | $RZFS receive $zfsreceive_flags
             $copydest"
         fi
       fi
@@ -1893,7 +1907,7 @@ $backup_file_dir/$backup_file_extension.$is_tail\" | $option_T sh"
 #
 
 # Read command line switches
-while getopts bBc:deE:f:Fg:hiI:klL:lmnN:o:O:pPPR:sST:u:Uvw?:D: i
+while getopts bBc:deE:f:Fg:hiI:klL:lmnN:o:O:pPPR:sST:u:Uvw?:D:z:Z: i
 do
   case $i in
     b)
@@ -2000,6 +2014,12 @@ do
       ;;
     w)
       option_w=1
+      ;;
+    z)
+      option_z="$OPTARG"
+      ;;
+    Z)
+      option_Z="$OPTARG"
       ;;
     \?)
       usage

--- a/zxfer.8
+++ b/zxfer.8
@@ -351,6 +351,7 @@ they are:
 If using -S, all filesystems in the pools containing the source directories/files 
 will be created on the destination if they aren't in existence already, whether
 they are to hold files/directories or not.
+This option is not compatible with -w.
 .It Fl S
 .Xr rsync 1 
 mode. 
@@ -587,6 +588,15 @@ Before replication begins, a list of supported properties is fetched from the
 destination and any properties not on that list are removed from the list of
 properties to be replicated.
 This allows replicating from newer versions of OpenZFS to older versions.
+This flag is incompatible with -w.
+.It Fl w
+Use the -w, --raw flag for zfs send. This enables sending encrypted datasets
+exactly as they exist on disk. This allows backups to be taken even if
+encryption keys are not loaded in the destination.
+This cannot be used after a non-raw send has been previously performed.
+This flag is incompatible with -U and -P.
+See also 
+.Xr zfs-send 8 .
 .El
 .Ss Rsync mode 
 (i.e. -S is specified)


### PR DESCRIPTION
Raw sends are incompatible with multiple features of zxfer like backing up
properties or sending encrypted datasets to older OpenZFS versions.
Nevertheless zxfer is still very useful in these cases due to the snapshot
handling logic, the newly added -w flag specifies that zfs send should perform
raw sends.
No checks are performed on either side as to whether or not they support these
flags, zfs (send|receive), and therefore zxfer will fail when it's not the case.

This patch has been tested, not to affect other workflows negatively and it works for the intended use-case. Sadly I currently lack the time to polish it some more and check more potentially incompatible flags.

This might also be considered to close #23.